### PR TITLE
$apache::serveradmin was unused

### DIFF
--- a/templates/httpd.conf.erb
+++ b/templates/httpd.conf.erb
@@ -5,6 +5,9 @@ TraceEnable <%= scope.call_function('apache::bool2httpd', [@trace_enable]) %>
 
 ServerName "<%= @servername %>"
 ServerRoot "<%= @server_root %>"
+<%- if @serveradmin -%>
+ServerAdmin <%= @serveradmin %>
+<%- end -%>
 PidFile <%= @pidfile %>
 Timeout <%= @timeout %>
 KeepAlive <%= @keepalive %>


### PR DESCRIPTION
This top-level parameter in the `::apache` class does not currently make it into the `httpd.conf` config file.